### PR TITLE
fix: .52ガロン/デコと.96ガロン/デコの画像がうまく表示されない問題の修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                                 <Typography className="player-name">{result.name}</Typography>
                                 <Typography className="weapon-name">{result.weapon}</Typography>
                                 <Typography className="weapon-image">
-                                    <img src={`images/weapons/${result.weapon}\.png`} alt={result.weapon} width={100} height={100} />
+                                    <img src={`images/weapons/${result.weapon.startsWith('.') ? `\\${result.weapon}` : result.weapon}\.png`} alt={result.weapon} width={100} height={100} />
                                 </Typography>
                             </Box>
                         ))}


### PR DESCRIPTION
## 概要

- #2 で追加した画像のうちガロン系統の画像だけうまく表示されない問題の修正をしました
- #2 の段階で、手元では問題なく表示されていたので環境依存の可能性がある……？
- ファイル名の開始がドット(.)で始まるのが問題っぽい(.はカレントディレクトリを指すのでファイルパスのパースがうまくいってない……？)のでエスケープしてみました